### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A UITableViewCell subclass for iOS 7 assisting in autolayout based dynamic heigh
 
 There is an example project included. Clone the repo and open "DBDynamicHeightTableCellDemo.xcworkspace".
 
-Mentioned by [Orta Therox](https://github.com/orta) of [Cocoapods](http://cocoapods.org) on his [Pod5 podcast - Episode 13](http://pod5.io/episode13/).
+Mentioned by [Orta Therox](https://github.com/orta) of [CocoaPods](http://cocoapods.org) on his [Pod5 podcast - Episode 13](http://pod5.io/episode13/).
 
 ## Usage
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
